### PR TITLE
Add extension for static factory method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.2.61'
     repositories {
         google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-beta01'
+        classpath 'com.android.tools.build:gradle:3.2.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/compiler/src/main/java/com/shaishavgandhi/navigator/ClassBuilder.kt
+++ b/compiler/src/main/java/com/shaishavgandhi/navigator/ClassBuilder.kt
@@ -1,0 +1,13 @@
+package com.shaishavgandhi.navigator
+
+import com.squareup.javapoet.ParameterSpec
+
+/**
+ * Data class representing an Activity/Fragment's builder class.
+ *
+ * This class contains the elements required for constructing the builder.
+ * i.e Activity/Fragment name, constructor params, optional params etc.
+ */
+data class ClassBuilder(val name: QualifiedClassName,
+                        val constructorParams: List<ParameterSpec>) {
+}

--- a/compiler/src/main/java/com/shaishavgandhi/navigator/ExtensionWriter.kt
+++ b/compiler/src/main/java/com/shaishavgandhi/navigator/ExtensionWriter.kt
@@ -1,6 +1,7 @@
 package com.shaishavgandhi.navigator
 
 import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import java.io.File
 import java.util.LinkedHashMap
 import java.util.LinkedHashSet
@@ -14,9 +15,73 @@ class ExtensionWriter(private val processingEnvironment: ProcessingEnvironment) 
     val elementUtil = processingEnvironment.elementUtils
     val messager = processingEnvironment.messager
 
-    val navigatorClass = ClassName.bestGuess("com.shaishavgandhi.navigator.Navigator")
+    private val navigatorClass = ClassName.bestGuess("com.shaishavgandhi.navigator.Navigator")
+    private val anyClass = ClassName.bestGuess("kotlin.Any")
+    private val kotlinArrayList = ClassName("kotlin.collections", "ArrayList")
 
-    fun generateExtensions(annotations: LinkedHashMap<QualifiedClassName, LinkedHashSet<Element>>) {
+    /**
+     * Java type -> Kotlin type mapper.
+     * When we're using annotation processing, the type of the
+     * elements still come as Java types. Since we're generating
+     * Kotlin extensions, this isn't ideal. Fortunately, we're
+     * dealing with a limited set of types with SharedPreferences,
+     * so we can map them by hand.
+     */
+    private val kotlinMapper = hashMapOf(
+        "java.lang.String" to ClassName("kotlin", "String"),
+
+        "java.lang.Long" to ClassName.bestGuess("kotlin.Long"),
+        "long" to ClassName.bestGuess("kotlin.Long"),
+        "long[]" to ClassName.bestGuess("LongArray"),
+        "java.lang.Long[]" to ClassName.bestGuess("LongArray"),
+
+        "int" to ClassName.bestGuess("kotlin.Int"),
+        "java.lang.Integer" to ClassName.bestGuess("kotlin.Int"),
+        "int[]" to ClassName.bestGuess("IntArray"),
+        "java.lang.Integer[]" to ClassName.bestGuess("IntArray"),
+
+        "boolean" to ClassName.bestGuess("kotlin.Boolean"),
+        "java.lang.Boolean" to ClassName.bestGuess("kotlin.Boolean"),
+        "boolean[]" to ClassName("kotlin", "BooleanArray"),
+        "java.lang.Boolean[]" to ClassName("kotlin", "BooleanArray"),
+
+        "float" to ClassName.bestGuess("kotlin.Float"),
+        "java.lang.Float" to ClassName.bestGuess("kotlin.Float"),
+        "float[]" to ClassName("kotlin", "FloatArray"),
+        "java.lang.Float[]" to ClassName("kotlin", "FloatArray"),
+
+        "java.lang.Double" to ClassName("kotlin", "Double"),
+        "double" to ClassName("kotlin", "Double"),
+        "double[]" to ClassName("kotlin", "DoubleArray"),
+        "java.lang.Double[]" to ClassName("kotlin", "DoubleArray"),
+
+        "byte" to ClassName("kotlin", "Byte"),
+        "java.lang.Byte" to ClassName("kotlin", "Byte"),
+        "byte[]" to ClassName("kotlin", "ByteArray"),
+        "java.lang.Byte[]" to ClassName("kotlin", "ByteArray"),
+
+        "short" to ClassName("kotlin", "Short"),
+        "java.lang.Short" to ClassName("kotlin","Short"),
+        "short[]" to ClassName("kotlin", "ShortArray"),
+        "java.lang.Short[]" to ClassName("kotlin","ShortArray"),
+
+        "char" to ClassName("kotlin", "Char"),
+        "java.lang.Character" to ClassName("kotlin", "Char"),
+        "char[]" to ClassName("kotlin", "CharArray"),
+        "java.lang.Character[]" to ClassName("kotlin", "CharArray"),
+
+        "java.lang.CharSequence" to ClassName("kotlin", "CharSequence"),
+        "java.lang.CharSequence[]" to ClassName("kotlin", "Array"),
+        "java.lang.CharSequence[]" to ClassName("kotlin", "Array")
+            .parameterizedBy(ClassName("kotlin", "CharSequence")),
+        "java.util.ArrayList<java.lang.CharSequence>" to kotlinArrayList
+            .parameterizedBy(ClassName("kotlin", "CharSequence"))
+    )
+
+    fun generateExtensions(
+        annotations: LinkedHashMap<QualifiedClassName, LinkedHashSet<Element>>,
+        classBuilders: List<ClassBuilder>
+    ) {
         val annotationsPerClass = LinkedHashMap<QualifiedClassName, LinkedHashSet<Element>>()
         annotationsPerClass.putAll(annotations)
         val kaptGeneratedDirPath = processingEnvironment.options["kapt.kotlin.generated"]
@@ -31,8 +96,8 @@ class ExtensionWriter(private val processingEnvironment: ProcessingEnvironment) 
             return
         }
 
-        for (entry in annotationsPerClass.entries) {
-            val className = entry.key.kotlinClass
+        for (classBuilder in classBuilders) {
+            val className = classBuilder.name.kotlinClass
 
             val extensionFileName = "${className.simpleName}NavigatorExtensions"
             val fileBuilder = FileSpec.builder(className.packageName, extensionFileName)
@@ -61,6 +126,33 @@ class ExtensionWriter(private val processingEnvironment: ProcessingEnvironment) 
                     .build())
                 .addStatement("%T.bind(this)", classBinder)
                 .build())
+
+            // Replacement for static constructor
+            val prepareFunctionBuilder = FunSpec.builder("prepare${className.simpleName}")
+                .receiver(anyClass)
+                .returns(ClassName.bestGuess("${className.simpleName}Builder"))
+
+            // Builder for return string so we can append parameters to it.
+            val returnBuilder = StringBuilder("return ${className.simpleName}Builder.builder(")
+
+            for (param in classBuilder.constructorParams) {
+                // Get return type considering Kotlin types
+                val returnType: TypeName = if (kotlinMapper[param.type.toString()] != null)
+                    kotlinMapper[param.type.toString()]!! else ClassName.bestGuess(param.type.toString())
+
+                // Add as a parameter.
+                prepareFunctionBuilder.addParameter(ParameterSpec.builder(param.name, returnType).build())
+                // Add to return statement.
+                returnBuilder.append("${param.name}, ")
+            }
+            // Remove leading ", " from the return statement
+            if (classBuilder.constructorParams.isNotEmpty()) {
+                returnBuilder.delete(returnBuilder.length - 2, returnBuilder.length)
+            }
+            returnBuilder.append(")")
+            // Add return statement
+            prepareFunctionBuilder.addStatement(returnBuilder.toString())
+            fileBuilder.addFunction(prepareFunctionBuilder.build())
 
             fileBuilder.build().writeTo(File(kaptGeneratedDirPath))
         }

--- a/compiler/src/main/java/com/shaishavgandhi/navigator/NavigatorProcessor.java
+++ b/compiler/src/main/java/com/shaishavgandhi/navigator/NavigatorProcessor.java
@@ -79,7 +79,7 @@ public final class NavigatorProcessor extends AbstractProcessor {
 
         FileWriter writer = new FileWriter(typeUtils, elementUtils, annotationsPerClass, messager);
         writer.writeFiles();
-        extensionWriter.generateExtensions(annotationsPerClass);
+        extensionWriter.generateExtensions(annotationsPerClass, writer.getClassBuilders());
 
         List<JavaFile> files = writer.getFiles();
         for (JavaFile file: files) {
@@ -94,7 +94,7 @@ public final class NavigatorProcessor extends AbstractProcessor {
         return true;
     }
 
-    private QualifiedClassName getClassName(Element element) {
+    private static QualifiedClassName getClassName(Element element) {
         String classname = element.getEnclosingElement().getSimpleName().toString();
         String packageName;
         Element enclosing = element;

--- a/compiler/src/main/java/com/shaishavgandhi/navigator/QualifiedClassName.kt
+++ b/compiler/src/main/java/com/shaishavgandhi/navigator/QualifiedClassName.kt
@@ -1,6 +1,8 @@
 package com.shaishavgandhi.navigator
 
 import com.squareup.javapoet.ClassName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeName
 
 data class QualifiedClassName(private val fullyQualifiedClassName: String) {
 
@@ -9,3 +11,5 @@ data class QualifiedClassName(private val fullyQualifiedClassName: String) {
 }
 
 typealias KtClassName = com.squareup.kotlinpoet.ClassName
+typealias KParameterSpec = ParameterSpec
+typealias KTypeName = TypeName

--- a/sample/src/main/java/com/shaishavgandhi/navigator/sample/DetailActivity.kt
+++ b/sample/src/main/java/com/shaishavgandhi/navigator/sample/DetailActivity.kt
@@ -25,9 +25,8 @@ class DetailActivity : AppCompatActivity() {
 
         Navigator.bind(this)
 
-        DetailFragmentBuilder()
-                .setUser(userList[0])
-                .bundle
+        DetailFragmentBuilder(userList.first()).bundle
+        prepareDetailFragment(user = userList.first())
         findViewById<TextView>(R.id.whatever).text = userList.first().name
 
     }

--- a/sample/src/main/java/com/shaishavgandhi/navigator/sample/DetailFragment.kt
+++ b/sample/src/main/java/com/shaishavgandhi/navigator/sample/DetailFragment.kt
@@ -22,7 +22,7 @@ private const val ARG_PARAM2 = "param2"
  */
 class DetailFragment : Fragment() {
 
-    @Extra var user: User? = null
+    @Extra lateinit var user: User
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
This adds a nice Kotlin extension to encapsulate the `YourActivityBuilder.builder(args)` static factory builder. The extension is generated on `Any` so it can be called from anywhere. 

This is useful for Kotlin consumers as it gives a nicer Kotlin API with named params. With this you can now do:

```kotlin
val bundle = prepareDetailFragment(userId = 1234, hook = "userOrigin").bundle
```

Opening up for discussion the extension method name. Possible candidates are:
```kotlin 
prepareDetailFragment(args).bundle
```
```kotlin
detailFragmentBuilder(args).bundle
```
```kotlin
detailFragment(args).bundle
```

Resolves #83 